### PR TITLE
Rework on CommonConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Configured with Kotlin and Android(which is quite heavy; excluded by default but
 
 
 ## License
-Virtual permissive license *_*
-You can do just anything with this template repository.
+Virtual permissive license `*_*`  
+You can do just anything with this template repository.  

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@
 kotlin = "1.6.10"
 coroutine = "1.6.0"
 serialization = "1.3.2"
-androidGradle = "7.1.2" # also in settings.gradle.kts
 
 
 [plugins]

--- a/includeBuild/build.gradle.kts
+++ b/includeBuild/build.gradle.kts
@@ -8,6 +8,7 @@ group = "com.lhwdev.include-build"
 
 repositories {
 	mavenCentral()
+	google()
 }
 
 gradlePlugin {
@@ -19,4 +20,5 @@ gradlePlugin {
 
 dependencies {
 	compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
+	compileOnly("com.android.tools.build:gradle:7.1.2")
 }

--- a/includeBuild/src/main/kotlin/com/lhwdev/build/CommonConfig.kt
+++ b/includeBuild/src/main/kotlin/com/lhwdev/build/CommonConfig.kt
@@ -2,23 +2,17 @@
 
 package com.lhwdev.build
 
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
-import org.gradle.api.plugins.ExtensionContainer
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import javax.inject.Inject
 
 
 /**
  * Not expected to be exhaustive kotlin/etc. configuration utility; created on demand.
  */
-open class CommonConfig @Inject constructor(private val project: Project) : ExtensionAware {
+open class CommonConfig @Inject constructor(internal val project: Project) {
 	init {
 		val extensions = (this as ExtensionAware).extensions
 		
@@ -32,105 +26,12 @@ open class CommonConfig @Inject constructor(private val project: Project) : Exte
 			val scope = extensions.create("kotlin", it, this, kotlin)
 			scope.setup()
 		}
-	}
-	
-	override fun getExtensions(): ExtensionContainer = error("stub!")
-}
-
-abstract class KotlinScope(protected val commonConfig: CommonConfig) {
-	protected abstract val kotlin: KotlinProjectExtension
-	
-	internal open fun setup() {
-		kotlin.sourceSets {
-			all {
-				languageSettings.apply {
-					enableLanguageFeature("InlineClasses")
-					optIn("kotlin.RequiresOptIn")
-					optIn("kotlin.ExperimentalUnsignedTypes")
-				}
-			}
-			
-			val testSourceSet = if(kotlin is KotlinMultiplatformExtension) "commonTest" else "test"
-			
-			named(testSourceSet) {
-				dependencies {
-					implementation(kotlin("test-common"))
-					implementation(kotlin("test-annotations-common"))
-				}
-			}
-		}
-	}
-}
-
-open class KotlinMultiplatformScope(commonConfig: CommonConfig, override val kotlin: KotlinMultiplatformExtension) :
-	KotlinScope(commonConfig) {
-	
-	val common = KotlinCommonItem(sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, "common"))
-	
-	
-	fun intermediate(name: String, setupBlock: KotlinIntermediateItem.() -> Unit = {}): KotlinIntermediateItem {
-		val item = KotlinIntermediateItem(
-			name = name,
-			sourceSet = kotlin.sourceSets.create(sourceSetNameFor(name, "main"))
-		)
 		
-		item.setupBlock()
-		
-		return item
-	}
-	
-	fun jvm(name: String, setupBlock: KotlinJvmItem.() -> Unit = {}): KotlinJvmItem {
-		val item = KotlinJvmItem(
-			sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, name = name)
-		)
-		
-		item.setupBlock()
-		
-		return item
+		initializeAndroid(extensions, project)
 	}
 }
 
-open class KotlinJvmScope(commonConfig: CommonConfig, override val kotlin: KotlinJvmProjectExtension) :
-	KotlinScope(commonConfig) {
-	
-	override fun setup() {
-		kotlin.sourceSets {
-			named("test") {
-				dependencies {
-					implementation(kotlin("test-junit"))
-				}
-			}
-		}
-	}
-}
+internal fun String.firstToUpperCase() = replaceRange(0, 1, first().toUpperCase().toString())
 
-
-class KotlinTargetSourceSet(val main: KotlinSourceSet, val test: KotlinSourceSet) {
-	constructor(sourceSets: NamedDomainObjectContainer<KotlinSourceSet>, name: String) : this(
-		main = sourceSets[sourceSetNameFor(name, "main")],
-		test = sourceSets[sourceSetNameFor(name, "test")]
-	)
-}
-
-
-abstract class KotlinItem
-
-abstract class KotlinTargetItem(internal val sourceSet: KotlinTargetSourceSet) : KotlinItem()
-
-class KotlinCommonItem(sourceSet: KotlinTargetSourceSet) : KotlinTargetItem(sourceSet = sourceSet) {
-	
-}
-
-class KotlinJvmItem(sourceSet: KotlinTargetSourceSet) : KotlinTargetItem(sourceSet = sourceSet) {
-	
-}
-
-
-class KotlinIntermediateItem(private val name: String, internal val sourceSet: KotlinSourceSet) : KotlinItem()
-
-
-
-private fun String.firstToUpperCase() = replaceRange(0, 1, first().toUpperCase().toString())
-
-private fun sourceSetNameFor(name: String?, type: String) =
+internal fun sourceSetNameFor(name: String?, type: String) =
 	if(name == null) type else "$name${type.firstToUpperCase()}"

--- a/includeBuild/src/main/kotlin/com/lhwdev/build/CommonConfig.kt
+++ b/includeBuild/src/main/kotlin/com/lhwdev/build/CommonConfig.kt
@@ -1,0 +1,136 @@
+@file:Suppress("LeakingThis")
+
+package com.lhwdev.build
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import javax.inject.Inject
+
+
+/**
+ * Not expected to be exhaustive kotlin/etc. configuration utility; created on demand.
+ */
+open class CommonConfig @Inject constructor(private val project: Project) : ExtensionAware {
+	init {
+		val extensions = (this as ExtensionAware).extensions
+		
+		val kotlin = project.extensions.findByName("kotlin")
+		when(kotlin) {
+			null -> null
+			is KotlinMultiplatformExtension -> KotlinMultiplatformScope::class.java
+			is KotlinJvmProjectExtension -> KotlinJvmScope::class.java
+			else -> error("not supported: $kotlin")
+		}?.let {
+			val scope = extensions.create("kotlin", it, this, kotlin)
+			scope.setup()
+		}
+	}
+	
+	override fun getExtensions(): ExtensionContainer = error("stub!")
+}
+
+abstract class KotlinScope(protected val commonConfig: CommonConfig) {
+	protected abstract val kotlin: KotlinProjectExtension
+	
+	internal open fun setup() {
+		kotlin.sourceSets {
+			all {
+				languageSettings.apply {
+					enableLanguageFeature("InlineClasses")
+					optIn("kotlin.RequiresOptIn")
+					optIn("kotlin.ExperimentalUnsignedTypes")
+				}
+			}
+			
+			val testSourceSet = if(kotlin is KotlinMultiplatformExtension) "commonTest" else "test"
+			
+			named(testSourceSet) {
+				dependencies {
+					implementation(kotlin("test-common"))
+					implementation(kotlin("test-annotations-common"))
+				}
+			}
+		}
+	}
+}
+
+open class KotlinMultiplatformScope(commonConfig: CommonConfig, override val kotlin: KotlinMultiplatformExtension) :
+	KotlinScope(commonConfig) {
+	
+	val common = KotlinCommonItem(sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, "common"))
+	
+	
+	fun intermediate(name: String, setupBlock: KotlinIntermediateItem.() -> Unit = {}): KotlinIntermediateItem {
+		val item = KotlinIntermediateItem(
+			name = name,
+			sourceSet = kotlin.sourceSets.create(sourceSetNameFor(name, "main"))
+		)
+		
+		item.setupBlock()
+		
+		return item
+	}
+	
+	fun jvm(name: String, setupBlock: KotlinJvmItem.() -> Unit = {}): KotlinJvmItem {
+		val item = KotlinJvmItem(
+			sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, name = name)
+		)
+		
+		item.setupBlock()
+		
+		return item
+	}
+}
+
+open class KotlinJvmScope(commonConfig: CommonConfig, override val kotlin: KotlinJvmProjectExtension) :
+	KotlinScope(commonConfig) {
+	
+	override fun setup() {
+		kotlin.sourceSets {
+			named("test") {
+				dependencies {
+					implementation(kotlin("test-junit"))
+				}
+			}
+		}
+	}
+}
+
+
+class KotlinTargetSourceSet(val main: KotlinSourceSet, val test: KotlinSourceSet) {
+	constructor(sourceSets: NamedDomainObjectContainer<KotlinSourceSet>, name: String) : this(
+		main = sourceSets[sourceSetNameFor(name, "main")],
+		test = sourceSets[sourceSetNameFor(name, "test")]
+	)
+}
+
+
+abstract class KotlinItem
+
+abstract class KotlinTargetItem(internal val sourceSet: KotlinTargetSourceSet) : KotlinItem()
+
+class KotlinCommonItem(sourceSet: KotlinTargetSourceSet) : KotlinTargetItem(sourceSet = sourceSet) {
+	
+}
+
+class KotlinJvmItem(sourceSet: KotlinTargetSourceSet) : KotlinTargetItem(sourceSet = sourceSet) {
+	
+}
+
+
+class KotlinIntermediateItem(private val name: String, internal val sourceSet: KotlinSourceSet) : KotlinItem()
+
+
+
+private fun String.firstToUpperCase() = replaceRange(0, 1, first().toUpperCase().toString())
+
+private fun sourceSetNameFor(name: String?, type: String) =
+	if(name == null) type else "$name${type.firstToUpperCase()}"

--- a/includeBuild/src/main/kotlin/com/lhwdev/build/CommonPlugin.kt
+++ b/includeBuild/src/main/kotlin/com/lhwdev/build/CommonPlugin.kt
@@ -7,6 +7,6 @@ import org.gradle.api.Project
 @Suppress("unused")
 class CommonPlugin : Plugin<Project> {
 	override fun apply(target: Project) {
-		// empty stub
+		target.extensions.create("commonConfig", CommonConfig::class.java)
 	}
 }

--- a/includeBuild/src/main/kotlin/com/lhwdev/build/android.kt
+++ b/includeBuild/src/main/kotlin/com/lhwdev/build/android.kt
@@ -1,0 +1,47 @@
+// Android dependencies and toolchains are large.
+// If you need android in your project, rename this file to .kt and uncomment `initializeAndroid` line from CommonConfig.kt.
+// And uncomment `compileOnly("com.android.tools.build:gradle:...")` from /includeBuild/build.gradle.kts.
+package com.lhwdev.build
+
+import com.android.build.gradle.BaseExtension
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionContainer
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
+
+
+internal fun initializeAndroid(extensions: ExtensionContainer, project: Project) {
+	val android = project.extensions.findByName("android") as? BaseExtension ?: return
+	
+	extensions.create("android", android::class.java)
+}
+
+
+fun KotlinMultiplatformScope.android(
+	name: String = "android",
+	setupBlock: KotlinAndroidItem.() -> Unit
+): KotlinAndroidItem {
+	val android = commonConfig.project.extensions.findByName("android") as? BaseExtension
+		?: error("android plugin was not configured")
+	
+	val target = kotlin.android(name)
+	val item = KotlinAndroidItem(
+		target = target,
+		sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, name = "android")
+	)
+	
+	android.sourceSets.all {
+		val directory = "src/${sourceSetNameFor(name, this.name)}"
+		setRoot(directory)
+	}
+	
+	item.setupBlock()
+	
+	return item
+}
+
+
+// mpp only
+class KotlinAndroidItem(
+	val target: KotlinAndroidTarget,
+	sourceSet: KotlinTargetSourceSet
+) : KotlinPlatformItem(sourceSet = sourceSet)

--- a/includeBuild/src/main/kotlin/com/lhwdev/build/kotlin.kt
+++ b/includeBuild/src/main/kotlin/com/lhwdev/build/kotlin.kt
@@ -1,0 +1,172 @@
+package com.lhwdev.build
+
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.invoke
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+
+
+abstract class KotlinScope(internal val commonConfig: CommonConfig) {
+	internal abstract val kotlin: KotlinProjectExtension
+	
+	internal open fun setup() {
+		kotlin.sourceSets {
+			all {
+				languageSettings.apply {
+					enableLanguageFeature("InlineClasses")
+					optIn("kotlin.RequiresOptIn")
+					optIn("kotlin.ExperimentalUnsignedTypes")
+				}
+			}
+			
+			val testSourceSet = if(kotlin is KotlinMultiplatformExtension) "commonTest" else "test"
+			
+			named(testSourceSet) {
+				dependencies {
+					implementation(kotlin("test-common"))
+					implementation(kotlin("test-annotations-common"))
+				}
+			}
+		}
+	}
+}
+
+open class KotlinMultiplatformScope(commonConfig: CommonConfig, override val kotlin: KotlinMultiplatformExtension) :
+	KotlinScope(commonConfig) {
+	
+	val common: KotlinCommonItem = KotlinCommonItem(sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, "common"))
+	
+	
+	fun intermediate(name: String, setupBlock: KotlinIntermediateItem.() -> Unit = {}): KotlinIntermediateItem {
+		val item = KotlinIntermediateItem(
+			name = name,
+			sourceSet = KotlinTargetSourceSet(
+				main = kotlin.sourceSets.create(sourceSetNameFor(name, type = "main")),
+				test = null
+				// test = kotlin.sourceSets.create(sourceSetNameFor(name, type = "test"))
+			)
+		)
+		
+		item.setupBlock()
+		
+		return item
+	}
+	
+	fun jvm(name: String = "jvm", setupBlock: KotlinJvmItem.() -> Unit = {}): KotlinJvmItem {
+		val target = kotlin.jvm(name)
+		val item = KotlinJvmItem(
+			target = target,
+			sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, name = name)
+		)
+		
+		item.setupBlock()
+		
+		return item
+	}
+}
+
+abstract class KotlinPlatformScope(commonConfig: CommonConfig) : KotlinScope(commonConfig) {
+	protected abstract val platformItem: KotlinPlatformItem
+	
+	fun dependencies(block: KotlinDependencyHandler.() -> Unit) {
+		platformItem.dependencies(block)
+	}
+	
+	fun testDependencies(block: KotlinDependencyHandler.() -> Unit) {
+		platformItem.testDependencies(block)
+	}
+}
+
+open class KotlinJvmScope(commonConfig: CommonConfig, final override val kotlin: KotlinJvmProjectExtension) :
+	KotlinPlatformScope(commonConfig) {
+	val jvm: KotlinJvmItem = KotlinJvmItem(
+		target = kotlin.target,
+		sourceSet = KotlinTargetSourceSet(kotlin.sourceSets, name = null)
+	)
+	
+	override val platformItem: KotlinPlatformItem
+		get() = jvm
+	
+	override fun setup() {
+		kotlin.sourceSets {
+			named("test") {
+				dependencies {
+					implementation(kotlin("test-junit"))
+				}
+			}
+		}
+	}
+}
+
+
+class KotlinTargetSourceSet(val main: KotlinSourceSet, val test: KotlinSourceSet?) {
+	constructor(sourceSets: NamedDomainObjectContainer<KotlinSourceSet>, name: String?) : this(
+		main = sourceSets[sourceSetNameFor(name, "main")],
+		test = sourceSets[sourceSetNameFor(name, "test")]
+	)
+}
+
+
+interface KotlinItem {
+	fun dependencies(block: KotlinDependencyHandler.() -> Unit)
+	
+	fun testDependencies(block: KotlinDependencyHandler.() -> Unit)
+}
+
+interface KotlinDependencyItem : KotlinItem {
+	val dependencySourceSet: KotlinTargetSourceSet
+}
+
+interface KotlinDependantItem : KotlinItem {
+	fun dependsOn(item: KotlinDependencyItem)
+}
+
+
+abstract class AbstractKotlinItem : KotlinItem {
+	protected abstract val targetSourceSet: KotlinTargetSourceSet
+	
+	fun dependsOn(item: KotlinDependencyItem) {
+		targetSourceSet.main.dependsOn(item.dependencySourceSet.main)
+	}
+	
+	override fun dependencies(block: KotlinDependencyHandler.() -> Unit) {
+		targetSourceSet.main.dependencies(block)
+	}
+	
+	override fun testDependencies(block: KotlinDependencyHandler.() -> Unit) {
+		targetSourceSet.test!!.dependencies(block)
+	}
+}
+
+abstract class KotlinTargetItem(internal val sourceSet: KotlinTargetSourceSet) : AbstractKotlinItem() {
+	override val targetSourceSet: KotlinTargetSourceSet get() = sourceSet
+}
+
+class KotlinCommonItem(sourceSet: KotlinTargetSourceSet) : KotlinTargetItem(sourceSet = sourceSet),
+	KotlinDependencyItem {
+	override val dependencySourceSet: KotlinTargetSourceSet get() = sourceSet
+}
+
+abstract class KotlinPlatformItem(sourceSet: KotlinTargetSourceSet) : KotlinTargetItem(sourceSet = sourceSet),
+	KotlinDependantItem
+
+class KotlinJvmItem(
+	val target: KotlinTarget,
+	sourceSet: KotlinTargetSourceSet
+) : KotlinPlatformItem(sourceSet = sourceSet) {
+}
+
+
+class KotlinIntermediateItem(
+	private val name: String,
+	internal val sourceSet: KotlinTargetSourceSet
+) : AbstractKotlinItem(), KotlinDependencyItem, KotlinDependantItem {
+	override val targetSourceSet: KotlinTargetSourceSet get() = sourceSet
+	override val dependencySourceSet: KotlinTargetSourceSet get() = sourceSet
+}
+

--- a/includeBuild/src/main/kotlin/com/lhwdev/build/utils.kt
+++ b/includeBuild/src/main/kotlin/com/lhwdev/build/utils.kt
@@ -1,180 +1,180 @@
-package com.lhwdev.build
-
-import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.Project
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.invoke
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaTarget
-import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
-import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
-
-
-// all common
-
-fun KotlinProjectExtension.setupCommon() {
-	sourceSets {
-		all {
-			languageSettings.apply {
-				enableLanguageFeature("InlineClasses")
-				optIn("kotlin.RequiresOptIn")
-				optIn("kotlin.ExperimentalUnsignedTypes")
-			}
-		}
-		
-		val testSourceSet = if(this@setupCommon is KotlinMultiplatformExtension) "commonTest" else "test"
-		
-		named(testSourceSet) {
-			dependencies {
-				implementation(kotlin("test-common"))
-				implementation(kotlin("test-annotations-common"))
-			}
-		}
-	}
-}
-
-
-// jvm
-
-private fun KotlinProjectExtension.setupJvmCommon(name: String?) {
-	sourceSets {
-		named(sourceSetNameFor(name, "test")) {
-			dependencies {
-				implementation(kotlin("test-junit"))
-			}
-		}
-	}
-}
-
-fun KotlinJvmProjectExtension.setup(init: (KotlinSetup<KotlinWithJavaTarget<KotlinJvmOptions>>.() -> Unit)? = null) {
-	setupCommon()
-	setupJvmCommon(null)
-	
-	target.compilations.all {
-		kotlinOptions.jvmTarget = "1.8"
-	}
-	
-	init?.invoke(KotlinSetup(target, null, sourceSets))
-}
-
-
-// mpp
-
-fun KotlinMultiplatformExtension.dependencies(name: String = "commonMain", block: KotlinDependencyHandler.() -> Unit) {
-	sourceSets {
-		named(name) {
-			dependencies(block)
-		}
-	}
-}
-
-fun KotlinMultiplatformExtension.library() {
-	setupCommon()
-	setupJvm()
-	// js {
-	// 	browser()
-	// 	nodejs()
-	// }
-	
-	// val hostOs = System.getProperty("os.name")
-	// val isMingwX64 = hostOs.startsWith("Windows")
-	// when {
-	// 	hostOs == "Mac OS X" -> macosX64("native")
-	// 	hostOs == "Linux" -> linuxX64("native")
-	// 	isMingwX64 -> mingwX64("native")
-	// 	else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-	// }
-}
-
-fun KotlinMultiplatformExtension.setupJvm(
-	name: String = "jvm",
-	init: (KotlinSetup<KotlinJvmTarget>.() -> Unit)? = null
-): KotlinJvmTarget {
-	val target = jvm(name) {
-		compilations.all {
-			kotlinOptions.jvmTarget = "1.8"
-		}
-	}
-	
-	setupJvmCommon(name)
-	init?.invoke(KotlinSetup(target, name, sourceSets))
-	return target
-}
-
-fun KotlinMultiplatformExtension.setupJs(
-	name: String = "js",
-	init: (KotlinSetup<KotlinJsTargetDsl>.() -> Unit)? = null
-): KotlinJsTargetDsl {
-	val target = js(name)
-	
-	sourceSets {
-		named("${name}Test") {
-			dependencies {
-				implementation(kotlin("test-js"))
-			}
-		}
-	}
-	
-	init?.invoke(KotlinSetup(target, name, sourceSets))
-	return target
-}
-
-// fun KotlinMultiplatformExtension.setupAndroid(
-// 	project: Project,
-// 	name: String = "android",
-// 	init: (KotlinSetup<KotlinAndroidTarget>.() -> Unit)? = null
-// ): KotlinAndroidTarget {
-// 	val target = android(name) {
+// package com.lhwdev.build
+//
+// import org.gradle.api.NamedDomainObjectContainer
+// import org.gradle.api.Project
+// import org.gradle.kotlin.dsl.getByType
+// import org.gradle.kotlin.dsl.invoke
+// import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+// import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+// import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+// import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+// import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+// import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+// import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+// import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
+// import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaTarget
+// import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
+// import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+//
+//
+// // all common
+//
+// fun KotlinProjectExtension.setupCommon() {
+// 	sourceSets {
+// 		all {
+// 			languageSettings.apply {
+// 				enableLanguageFeature("InlineClasses")
+// 				optIn("kotlin.RequiresOptIn")
+// 				optIn("kotlin.ExperimentalUnsignedTypes")
+// 			}
+// 		}
+//		
+// 		val testSourceSet = if(this@setupCommon is KotlinMultiplatformExtension) "commonTest" else "test"
+//		
+// 		named(testSourceSet) {
+// 			dependencies {
+// 				implementation(kotlin("test-common"))
+// 				implementation(kotlin("test-annotations-common"))
+// 			}
+// 		}
+// 	}
+// }
+//
+//
+// // jvm
+//
+// private fun KotlinProjectExtension.setupJvmCommon(name: String?) {
+// 	sourceSets {
+// 		named(sourceSetNameFor(name, "test")) {
+// 			dependencies {
+// 				implementation(kotlin("test-junit"))
+// 			}
+// 		}
+// 	}
+// }
+//
+// fun KotlinJvmProjectExtension.setup(init: (KotlinSetup<KotlinWithJavaTarget<KotlinJvmOptions>>.() -> Unit)? = null) {
+// 	setupCommon()
+// 	setupJvmCommon(null)
+//	
+// 	target.compilations.all {
+// 		kotlinOptions.jvmTarget = "1.8"
+// 	}
+//	
+// 	init?.invoke(KotlinSetup(target, null, sourceSets))
+// }
+//
+//
+// // mpp
+//
+// fun KotlinMultiplatformExtension.dependencies(name: String = "commonMain", block: KotlinDependencyHandler.() -> Unit) {
+// 	sourceSets {
+// 		named(name) {
+// 			dependencies(block)
+// 		}
+// 	}
+// }
+//
+// fun KotlinMultiplatformExtension.library() {
+// 	setupCommon()
+// 	setupJvm()
+// 	// js {
+// 	// 	browser()
+// 	// 	nodejs()
+// 	// }
+//	
+// 	// val hostOs = System.getProperty("os.name")
+// 	// val isMingwX64 = hostOs.startsWith("Windows")
+// 	// when {
+// 	// 	hostOs == "Mac OS X" -> macosX64("native")
+// 	// 	hostOs == "Linux" -> linuxX64("native")
+// 	// 	isMingwX64 -> mingwX64("native")
+// 	// 	else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
+// 	// }
+// }
+//
+// fun KotlinMultiplatformExtension.setupJvm(
+// 	name: String = "jvm",
+// 	init: (KotlinSetup<KotlinJvmTarget>.() -> Unit)? = null
+// ): KotlinJvmTarget {
+// 	val target = jvm(name) {
 // 		compilations.all {
 // 			kotlinOptions.jvmTarget = "1.8"
 // 		}
 // 	}
-//
+//	
 // 	setupJvmCommon(name)
 // 	init?.invoke(KotlinSetup(target, name, sourceSets))
-//
-// 	project.extensions.getByType<BaseExtension>().sourceSets.all {
-// 		val directory = "src/$name${this.name.firstToUpperCase()}"
-// 		setRoot(directory)
-// 	}
-//
 // 	return target
 // }
-
-
-private fun String.firstToUpperCase() = replaceRange(0, 1, first().toUpperCase().toString())
-
-private fun sourceSetNameFor(name: String?, type: String) =
-	if(name == null) type else "$name${type.firstToUpperCase()}"
-
-
-class KotlinSetup<Target : KotlinTarget>(
-	val target: Target,
-	val name: String?,
-	val sourceSet: NamedDomainObjectContainer<KotlinSourceSet>
-) {
-	fun target(block: Target.() -> Unit) {
-		target.block()
-	}
-	
-	private fun dependencies(type: String, block: KotlinDependencyHandler.() -> Unit) {
-		sourceSet.named(sourceSetNameFor(name, type)) {
-			dependencies(block)
-		}
-	}
-	
-	fun dependencies(block: KotlinDependencyHandler.() -> Unit) {
-		dependencies("main", block)
-	}
-	
-	fun testDependencies(block: KotlinDependencyHandler.() -> Unit) {
-		dependencies("test", block)
-	}
-}
+//
+// fun KotlinMultiplatformExtension.setupJs(
+// 	name: String = "js",
+// 	init: (KotlinSetup<KotlinJsTargetDsl>.() -> Unit)? = null
+// ): KotlinJsTargetDsl {
+// 	val target = js(name)
+//	
+// 	sourceSets {
+// 		named("${name}Test") {
+// 			dependencies {
+// 				implementation(kotlin("test-js"))
+// 			}
+// 		}
+// 	}
+//	
+// 	init?.invoke(KotlinSetup(target, name, sourceSets))
+// 	return target
+// }
+//
+// // fun KotlinMultiplatformExtension.setupAndroid(
+// // 	project: Project,
+// // 	name: String = "android",
+// // 	init: (KotlinSetup<KotlinAndroidTarget>.() -> Unit)? = null
+// // ): KotlinAndroidTarget {
+// // 	val target = android(name) {
+// // 		compilations.all {
+// // 			kotlinOptions.jvmTarget = "1.8"
+// // 		}
+// // 	}
+// //
+// // 	setupJvmCommon(name)
+// // 	init?.invoke(KotlinSetup(target, name, sourceSets))
+// //
+// // 	project.extensions.getByType<BaseExtension>().sourceSets.all {
+// // 		val directory = "src/$name${this.name.firstToUpperCase()}"
+// // 		setRoot(directory)
+// // 	}
+// //
+// // 	return target
+// // }
+//
+//
+// private fun String.firstToUpperCase() = replaceRange(0, 1, first().toUpperCase().toString())
+//
+// private fun sourceSetNameFor(name: String?, type: String) =
+// 	if(name == null) type else "$name${type.firstToUpperCase()}"
+//
+//
+// class KotlinSetup<Target : KotlinTarget>(
+// 	val target: Target,
+// 	val name: String?,
+// 	val sourceSet: NamedDomainObjectContainer<KotlinSourceSet>
+// ) {
+// 	fun target(block: Target.() -> Unit) {
+// 		target.block()
+// 	}
+//	
+// 	private fun dependencies(type: String, block: KotlinDependencyHandler.() -> Unit) {
+// 		sourceSet.named(sourceSetNameFor(name, type)) {
+// 			dependencies(block)
+// 		}
+// 	}
+//	
+// 	fun dependencies(block: KotlinDependencyHandler.() -> Unit) {
+// 		dependencies("main", block)
+// 	}
+//	
+// 	fun testDependencies(block: KotlinDependencyHandler.() -> Unit) {
+// 		dependencies("test", block)
+// 	}
+// }

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
 
 commonConfig {
 	kotlin {
-		
+		dependencies {
+			
+		}
 	}
 }
 

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -1,17 +1,20 @@
-import com.lhwdev.build.*
-
-
 plugins {
 	kotlin("jvm")
 	
 	id("common-plugin") // must be applied after Kotlin/Android plugins
 }
 
-kotlin {
-	setup()
+commonConfig {
+	kotlin {
+		
+	}
 }
 
-
-dependencies {
-	// implementation(projects.abc) // this is available thanks to https://docs.gradle.org/7.4/userguide/declaring_dependencies.html#sec:type-safe-project-accessors
-}
+// kotlin {
+// 	setup()
+// }
+//
+//
+// dependencies {
+// 	// implementation(projects.abc) // this is available thanks to https://docs.gradle.org/7.4/userguide/declaring_dependencies.html#sec:type-safe-project-accessors
+// }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
 		
 		// Android
 		if(id.startsWith("com.android")) {
-			useModule("com.android.tools.build:gradle:7.1.2")
+			useModule("com.android.tools.build:gradle:7.1.2") // synchronize with includeBuild/build.gradle.kts version
 		}
 	}
 }


### PR DESCRIPTION
- scope things into `commonConfig {}` block to avoid confusion
- abstract away most apis